### PR TITLE
Update target framework and modify settings

### DIFF
--- a/src/TypeLibRegisterCS/TypeLibRegisterCS.csproj
+++ b/src/TypeLibRegisterCS/TypeLibRegisterCS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows7.0</TargetFramework>
     <OutputType>WinExe</OutputType>
     <ApplicationIcon>TypeLibRegisterCS.ico</ApplicationIcon>
     <SignAssembly>true</SignAssembly>

--- a/src/TypeLibRegisterCS/TypeLibRegisterCS.sln.DotSettings
+++ b/src/TypeLibRegisterCS/TypeLibRegisterCS.sln.DotSettings
@@ -228,13 +228,14 @@
 	<s:Boolean x:Key="/Default/CodeStyle/EditorConfig/EnableStyleCopSupport/@EntryValue">True</s:Boolean>
 	
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">--------------------------------------------------------------------------------------------------------------------&#xD;
-&lt;copyright file="$FILENAME$" company="MareMare"&gt;&#xD;
+&lt;copyright file="${File.FileName}" company="MareMare"&gt;&#xD;
 Copyright © 2010 MareMare. All rights reserved.&#xD;
 Licensed under the MIT license. See LICENSE file in the project root for full license information.&#xD;
 &lt;/copyright&gt;&#xD;
 --------------------------------------------------------------------------------------------------------------------&#xD;
 </s:String>
 	<s:String x:Key="/Default/Environment/Hierarchy/PsiConfigurationSettingsKey/LocationType/@EntryValue">SOLUTION_FOLDER</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	
 	
 	
@@ -245,6 +246,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002EMemberReordering_002EMigrations_002ECSharpFileLayoutPatternRemoveIsAttributeUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	</wpf:ResourceDictionary>


### PR DESCRIPTION
Changed target framework from `net6.0-windows` to `net8.0-windows7.0` in the `TypeLibRegisterCS.csproj` file. This allows new .NET 8 features to be available.

In the `TypeLibRegisterCS.sln.DotSettings` file, the format of the copyright information has been corrected, replacing `$FILENAME$` with `${File.FileName}`. Also, a new boolean value for settings migration has been added to indicate that migration of certain code style settings has been applied.

Translated with DeepL.com (free version)